### PR TITLE
README JSDoc syntax fix

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,10 +65,11 @@ const {
 /**
  * @param {string} package1 - new package
  * @param {string} package2 - old package (can be as version or tag)
- * @param {boolean} full=true - flag for full check, 
+ * @param {Object} options - comparison options
+ * @param {boolean} options.full=true - flag for full check, 
    if "false" compare function will stop on first diff and returns boolean (package equals: true or has diff: false)
- * @param {string} exclude - exclude glob for unix "diff"
- * @param {boolean} toStdOut - all diff output to stdOut
+ * @param {string} options.exclude - exclude glob for unix "diff"
+ * @param {boolean} options.toStdOut - all diff output to stdOut
  *
  * @returns {Promise<boolean|string|undefined>}
 */

--- a/src/compare.js
+++ b/src/compare.js
@@ -145,9 +145,10 @@ const unpack = async (tar, sessionDir) => {
  *
  * @param {string} package1
  * @param {string} package2
- * @param {boolean} full
- * @param {string} exclude
- * @param {boolean} toStdOut
+ * @param {Object} options - comparison options
+ * @param {boolean} options.full=true
+ * @param {string} options.exclude
+ * @param {boolean} options.toStdOut
  *
  * @returns {Promise<boolean|string|undefined>}
  */


### PR DESCRIPTION
JSDoc params syntax fix in README.md. [Syntax](https://jsdoc.app/tags-param.html#parameters-with-properties)